### PR TITLE
Remove unused dev_test dep, replace with standard test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dev_dependencies:
   test: '>=0.12.0'
-  dev_test: '>=0.12.0'
   chrome_travis:
     git:
       url: git://github.com/tekartik/chrome_travis.dart

--- a/test/issues_test.dart
+++ b/test/issues_test.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 
-import 'package:dev_test/test.dart';
 import 'package:synchronized/src/utils.dart';
 import 'package:synchronized/synchronized.dart' hide SynchronizedLock;
+import 'package:test/test.dart';
 
 import 'test_common.dart';
 

--- a/test/lock_test.dart
+++ b/test/lock_test.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 
-import 'package:dev_test/test.dart';
 import 'package:synchronized/src/utils.dart';
 import 'package:synchronized/synchronized.dart' hide SynchronizedLock;
+import 'package:test/test.dart';
 
 import 'test_common.dart';
 

--- a/test/reentrant_lock_test.dart
+++ b/test/reentrant_lock_test.dart
@@ -3,8 +3,8 @@
 
 import 'dart:async';
 
-import 'package:dev_test/test.dart';
 import 'package:synchronized/synchronized.dart' hide SynchronizedLock;
+import 'package:test/test.dart';
 
 import 'lock_test.dart';
 import 'test_common.dart';

--- a/test/synchronized_compat_test.dart
+++ b/test/synchronized_compat_test.dart
@@ -3,8 +3,8 @@
 
 import 'dart:async';
 
-import 'package:dev_test/test.dart';
 import 'package:synchronized/synchronized.dart';
+import 'package:test/test.dart';
 
 import 'lock_test.dart';
 import 'test_common.dart';

--- a/test/synchronized_impl_test.dart
+++ b/test/synchronized_impl_test.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:synchronized/src/synchronized_impl.dart';
 import 'package:synchronized/src/utils.dart';
 import 'package:synchronized/synchronized.dart' as common;
-import 'package:dev_test/test.dart';
+import 'package:test/test.dart';
 
 import 'test_common.dart';
 

--- a/test/synchronized_test.dart
+++ b/test/synchronized_test.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:dev_test/test.dart';
 import 'package:synchronized/src/synchronized_impl.dart' show ReentrantLock;
+import 'package:test/test.dart';
 import 'test_common.dart';
 
 // To make tests less verbose...


### PR DESCRIPTION
Simplifies dependencies for synchronized. Nothing dev_test specific is used in the tests.