### PR TITLE
Use Dart 2.12 for null safety

### DIFF
--- a/synchronized/analysis_options.yaml
+++ b/synchronized/analysis_options.yaml
@@ -4,10 +4,8 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
-  enable-experiment:
-    - non-nullable
-  strong-mode:
-    implicit-casts: false
+  # strong-mode:
+    #implicit-casts: false
     # implicit-dynamic: false
 
 linter:

--- a/synchronized/pubspec.yaml
+++ b/synchronized/pubspec.yaml
@@ -4,12 +4,12 @@ version: 2.2.0+2
 homepage: https://github.com/tekartik/synchronized.dart/tree/master/synchronized
 
 environment:
-  sdk: '>=2.11.0-0 <2.12.0'
+  sdk: '>=2.12.0-0 <2.12.0'
 
 dev_dependencies:
   pedantic: '>=1.9.0 <3.0.0'
   pub_semver: '>=1.4.4'
-  test: '>=1.15.3'
+  test: '>=1.16.0-nullsafety'
   build_runner: '>=1.10.2'
   build_test: '>=1.2.1'
   build_web_compilers: '>=1.1.0'

--- a/synchronized/tool/tag.dart
+++ b/synchronized/tool/tag.dart
@@ -1,3 +1,4 @@
+//@dart=2.9
 import 'dart:io';
 
 import 'package:io/io.dart';

--- a/synchronized/tool/travis.dart
+++ b/synchronized/tool/travis.dart
@@ -1,28 +1,27 @@
+//@dart=2.9
+import 'dart:io';
+
 import 'package:process_run/shell.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 Future<void> main() async {
   var shell = Shell();
 
-  var nnbdEnabled = dartVersion > Version(2, 10, 0, pre: '92');
-  var dartExtraOptions = '';
+  var nnbdEnabled = dartVersion > Version(2, 12, 0, pre: '0');
   var dartRunExtraOptions = '';
+  var dart = Platform.executable;
+
   if (nnbdEnabled) {
-    // Temp dart extra option. To remove once nnbd supported on stable without flags
-    dartExtraOptions = '--enable-experiment=non-nullable';
     // Needed for run and test
-    dartRunExtraOptions =
-        '--enable-experiment=non-nullable --no-sound-null-safety';
+    dartRunExtraOptions = '--no-sound-null-safety';
 
     await shell.run('''
 
-dartanalyzer $dartExtraOptions --fatal-warnings --fatal-infos .
-dartfmt -n --set-exit-if-changed .
+$dart analyze --fatal-warnings --fatal-infos .
+$dart format -o none --set-exit-if-changed .
 
-pub run $dartRunExtraOptions test -p vm -j 1
-# NNBD failing - dart $dartRunExtraOptions pub run build_runner test -- -p vm -j 1
-# NNBD failing - pub run $dartRunExtraOptions test -p chrome,firefox -j 1
-# NNBD failing - pub run $dartRunExtraOptions build_runner test -- -p chrome -j 1
+$dart $dartRunExtraOptions run  test -p vm,chrome,firefox -j 1
+$dart $dartRunExtraOptions run build_runner test -- -p vm,chrome -j 1
   ''');
   }
 }

--- a/tool/travis.dart
+++ b/tool/travis.dart
@@ -6,12 +6,12 @@ import 'package:pub_semver/pub_semver.dart';
 Future<void> main() async {
   var shell = Shell();
 
-  var nnbdEnabled = dartVersion > Version(2, 11, 0, pre: '0');
+  var nnbdEnabled = dartVersion > Version(2, 12, 0, pre: '0');
   var dartExtraOptions = '';
   var dartRunExtraOptions = '';
+  var dart = Platform.executable;
+
   if (nnbdEnabled) {
-    // Temp dart extra option. To remove once nnbd supported on stable without flags
-    dartExtraOptions = '--enable-experiment=non-nullable';
     // Needed for run and test
     dartRunExtraOptions = '$dartExtraOptions --no-sound-null-safety';
 
@@ -20,8 +20,8 @@ Future<void> main() async {
       stdout.writeln('package: $dir');
       await shell.run('''
 
-dart $dartExtraOptions pub get
-dart $dartRunExtraOptions run tool/travis.dart
+$dart $dartExtraOptions pub get
+$dart $dartRunExtraOptions run tool/travis.dart
 
     ''');
       shell = shell.popd();


### PR DESCRIPTION
Hi @alextekartik, and thanks for starting to migrate this package. I tried to use your `null_safety` branch in my projects but the 2.11 minimum constraint prevented it from working. This PR enables support for the Dart 2.12 sdk. This might help you, feel free to just close this otherwise.

Dart 2.12 enables null-safety without an experiment flag, so I raised the lower SDK constraint and fixed analysis warnings. The browser tests seem to work now (at least they worked on my machine), so I uncommented them. I also adapted the tool scripts to optionally use a different executable, making them easier to run with more than one Dart installation.
I added a `@dart=2.9` comment to files which import packages that haven't been migrated yet (this only affects tooling).