### PR TITLE
fix: handle returning futures correctly

### DIFF
--- a/synchronized/lib/src/basic_lock.dart
+++ b/synchronized/lib/src/basic_lock.dart
@@ -29,7 +29,7 @@ class BasicLock implements Lock {
 
       // Run the function and return the result
       var result = func();
-      if (result is Future) {
+      if (result is Future && result is! T) {
         return await result;
       } else {
         return result;

--- a/synchronized/lib/src/reentrant_lock.dart
+++ b/synchronized/lib/src/reentrant_lock.dart
@@ -33,7 +33,7 @@ class ReentrantLock implements Lock {
         var result = runZoned(() {
           return func();
         }, zoneValues: {this: level + 1});
-        if (result is Future) {
+        if (result is Future && result is! T) {
           return await result;
         } else {
           return result;

--- a/synchronized/test/common_lock_test_.dart
+++ b/synchronized/test/common_lock_test_.dart
@@ -63,6 +63,44 @@ void lockMain(LockFactory lockFactory) {
       expect(await value1, 'value1');
     });
 
+    group('futures', () {
+      // if the return type is a not a future, return the result of the future
+      test('future_awaited', () async {
+        final lock = newLock();
+        final future = Future.delayed(const Duration(seconds: 1), () => true);
+
+        final value = await lock.synchronized(() {
+          return future;
+        });
+
+        expect(value, isA<bool>());
+      });
+
+      // if the return type is a Future, return the future
+      test('future_returned', () async {
+        final lock = newLock();
+        final future = Future.delayed(const Duration(seconds: 1), () => true);
+
+        final value = await lock.synchronized<Future<bool>>(() {
+          return future;
+        });
+
+        expect(value, isA<Future<bool>>());
+      });
+
+      // if the function is async, return the correct type
+      test('future_async', () async {
+        final lock = newLock();
+        final future = Future.delayed(const Duration(seconds: 1), () => true);
+
+        final value = await lock.synchronized<Future<bool>>(() async {
+          return future;
+        });
+
+        expect(value, isA<Future<bool>>());
+      });
+    });
+
     group('perf', () {
       final operationCount = 10000;
 


### PR DESCRIPTION
This fixes an issue where the lock would await a returned Future
(assuming the function was async), even if the return type was a Future.
Now the function result is only awaited, if it does not match the
generic type of the `Lock.synchronized` function.